### PR TITLE
feat(ui): HUD e inventário no overworld

### DIFF
--- a/battleSystem/data/characters/enemy1.tres
+++ b/battleSystem/data/characters/enemy1.tres
@@ -7,7 +7,7 @@
 [resource]
 script = ExtResource("1_5abhp")
 metadata/_custom_type_script = "uid://b43yrin0qlny4"
-name = "Orc Grunt"
+name = "Orc Recruta"
 level = 1
 experience = 0
 maxHealth = 60

--- a/battleSystem/data/characters/enemy2.tres
+++ b/battleSystem/data/characters/enemy2.tres
@@ -9,7 +9,7 @@
 [resource]
 script = ExtResource("1_10npn")
 metadata/_custom_type_script = "uid://b43yrin0qlny4"
-name = "Echo Shade"
+name = "Sombra do Eco"
 level = 1
 experience = 0
 maxHealth = 45

--- a/battleSystem/data/characters/enemy3.tres
+++ b/battleSystem/data/characters/enemy3.tres
@@ -9,7 +9,7 @@
 [resource]
 script = ExtResource("1_iioin")
 metadata/_custom_type_script = "uid://b43yrin0qlny4"
-name = "Stone Guard"
+name = "Guarda de Pedra"
 level = 1
 experience = 0
 maxHealth = 80

--- a/battleSystem/data/characters/player1.tres
+++ b/battleSystem/data/characters/player1.tres
@@ -8,7 +8,7 @@
 [resource]
 script = ExtResource("1_umnqp")
 metadata/_custom_type_script = "uid://b43yrin0qlny4"
-name = "Hero"
+name = "Herói"
 level = 1
 experience = 0
 maxHealth = 100

--- a/battleSystem/data/combos/focus_strike.tres
+++ b/battleSystem/data/combos/focus_strike.tres
@@ -6,7 +6,7 @@
 
 [resource]
 script = ExtResource("1_combo")
-name = "Focus Strike"
+name = "Golpe Focado"
 targetType = 0
 skillType = 0
 power = 45
@@ -16,6 +16,6 @@ hitCount = 1
 element = 1
 animationKey = "focus_strike"
 requiresAliveTarget = true
-participantNames = Array[StringName]([&"Hero", &"Lumen"])
+participantNames = Array[StringName]([&"Herói", &"Lumen"])
 requiredTechs = Array[Resource]([ExtResource("2_slash"), ExtResource("3_heal")])
 participantManaCosts = Array[int]([6, 8])

--- a/battleSystem/data/items/potion.tres
+++ b/battleSystem/data/items/potion.tres
@@ -4,10 +4,11 @@
 
 [resource]
 script = ExtResource("1_item")
-name = "Potion"
-description = "Restores HP to one ally."
+name = "Poção"
+description = "Restaura HP de um aliado."
 effectType = 0
 power = 35
 targetType = 1
 targetScope = 0
 usableInBattle = true
+usableInWorld = true

--- a/battleSystem/data/skills/Attack.tres
+++ b/battleSystem/data/skills/Attack.tres
@@ -5,7 +5,7 @@
 [resource]
 script = ExtResource("1_68qga")
 metadata/_custom_type_script = "uid://c421fsjpurk6x"
-name = "Attack"
+name = "Ataque"
 targetType = 0
 skillType = 0
 power = 15

--- a/battleSystem/data/skills/Heal.tres
+++ b/battleSystem/data/skills/Heal.tres
@@ -5,7 +5,7 @@
 [resource]
 script = ExtResource("1_k4eyv")
 metadata/_custom_type_script = "uid://c421fsjpurk6x"
-name = "Heal"
+name = "Cura"
 targetType = 1
 skillType = 1
 power = 25

--- a/battleSystem/data/skills/Slash.tres
+++ b/battleSystem/data/skills/Slash.tres
@@ -5,7 +5,7 @@
 [resource]
 script = ExtResource("1_6vb83")
 metadata/_custom_type_script = "uid://c421fsjpurk6x"
-name = "Slash"
+name = "Talho"
 targetType = 0
 skillType = 0
 power = 22

--- a/battleSystem/resources/item_resource.gd
+++ b/battleSystem/resources/item_resource.gd
@@ -8,6 +8,7 @@ class_name ItemResource
 @export var targetType: Target_Type = Target_Type.PLAYERS
 @export var targetScope: Target_Scope = Target_Scope.SINGLE_TARGET
 @export var usableInBattle := true
+@export var usableInWorld := false
 
 enum Effect_Type { HEAL_HP, RESTORE_MP, DAMAGE }
 enum Target_Type { ENEMIES, PLAYERS }
@@ -15,6 +16,9 @@ enum Target_Scope { SINGLE_TARGET, ALL_TARGETS, SELF }
 
 func can_use_in_battle() -> bool:
 	return usableInBattle
+
+func can_use_in_world() -> bool:
+	return usableInWorld
 
 func apply_to(target: CharacterResource) -> void:
 	if target == null:

--- a/project.godot
+++ b/project.godot
@@ -19,6 +19,8 @@ config/icon="res://icon.svg"
 
 GameData="*uid://djlcbdgiila7k"
 BattleTransition="*res://world/battle_transition.gd"
+WorldHud="*res://ui/hud/world_hud.tscn"
+WorldInventory="*res://ui/hud/world_inventory.tscn"
 
 [display]
 
@@ -60,6 +62,11 @@ attack={
 interact={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"location":0,"echo":false,"script":null)
+]
+}
+inventory={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":73,"key_label":0,"unicode":105,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/ui/hud/world_hud.gd
+++ b/ui/hud/world_hud.gd
@@ -1,0 +1,55 @@
+extends CanvasLayer
+
+const OVERWORLD_PATH_PREFIX := "res://world/"
+const EXCLUDED_PATH_FRAGMENTS := ["tittle_screen", "troca_fase"]
+
+@onready var root_panel: PanelContainer = $Root
+@onready var name_level_label: Label = %NameLevelLabel
+@onready var hp_bar: ProgressBar = %HpBar
+@onready var hp_text: Label = %HpText
+@onready var mp_bar: ProgressBar = %MpBar
+@onready var mp_text: Label = %MpText
+@onready var gold_label: Label = %GoldLabel
+
+func _ready() -> void:
+	layer = 10
+	hide()
+
+func _process(_delta: float) -> void:
+	if not _should_display():
+		hide()
+		return
+	show()
+	_refresh()
+
+func _should_display() -> bool:
+	var current := get_tree().current_scene
+	if current == null:
+		return false
+	var path := current.scene_file_path
+	if not path.begins_with(OVERWORLD_PATH_PREFIX):
+		return false
+	for fragment in EXCLUDED_PATH_FRAGMENTS:
+		if path.contains(fragment):
+			return false
+	return true
+
+func _refresh() -> void:
+	var party := GameData.party_resources
+	if party.is_empty() or party[0] == null:
+		root_panel.hide()
+		return
+	root_panel.show()
+
+	var character: CharacterResource = party[0]
+	name_level_label.text = "%s  Nv.%d" % [character.name, character.level]
+
+	hp_bar.max_value = max(1, character.maxHealth)
+	hp_bar.value = character.currentHealth
+	hp_text.text = "%d/%d" % [character.currentHealth, character.maxHealth]
+
+	mp_bar.max_value = max(1, character.maxMana)
+	mp_bar.value = character.currentMana
+	mp_text.text = "%d/%d" % [character.currentMana, character.maxMana]
+
+	gold_label.text = "$ %d" % GameData.gold

--- a/ui/hud/world_hud.tscn
+++ b/ui/hud/world_hud.tscn
@@ -1,0 +1,128 @@
+[gd_scene load_steps=6 format=3 uid="uid://b8w0rldhud0001"]
+
+[ext_resource type="Script" path="res://ui/hud/world_hud.gd" id="1_script"]
+[ext_resource type="Texture2D" uid="uid://b1w5bj6vkt8qq" path="res://assets/sprites/characters/Knights/Swordman.png" id="2_portrait"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_portrait"]
+atlas = ExtResource("2_portrait")
+region = Rect2(0, 0, 48, 48)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panel"]
+bg_color = Color(0, 0, 0, 0.6)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(1, 1, 1, 0.45)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[node name="WorldHud" type="CanvasLayer"]
+layer = 10
+script = ExtResource("1_script")
+
+[node name="Root" type="PanelContainer" parent="."]
+offset_left = 12.0
+offset_top = 12.0
+offset_right = 280.0
+offset_bottom = 96.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_panel")
+
+[node name="Margin" type="MarginContainer" parent="Root"]
+layout_mode = 2
+theme_override_constants/margin_left = 8
+theme_override_constants/margin_top = 6
+theme_override_constants/margin_right = 8
+theme_override_constants/margin_bottom = 6
+
+[node name="HBox" type="HBoxContainer" parent="Root/Margin"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="Portrait" type="TextureRect" parent="Root/Margin/HBox"]
+custom_minimum_size = Vector2(56, 56)
+layout_mode = 2
+texture = SubResource("AtlasTexture_portrait")
+expand_mode = 1
+stretch_mode = 5
+
+[node name="Stats" type="VBoxContainer" parent="Root/Margin/HBox"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 2
+
+[node name="NameLevelLabel" type="Label" parent="Root/Margin/HBox/Stats"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 16
+text = "Hero  Lv.1"
+
+[node name="HpRow" type="HBoxContainer" parent="Root/Margin/HBox/Stats"]
+layout_mode = 2
+theme_override_constants/separation = 6
+
+[node name="HpLabel" type="Label" parent="Root/Margin/HBox/Stats/HpRow"]
+custom_minimum_size = Vector2(24, 0)
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.45, 0.45, 1)
+theme_override_font_sizes/font_size = 14
+text = "HP"
+
+[node name="HpBar" type="ProgressBar" parent="Root/Margin/HBox/Stats/HpRow"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(120, 10)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
+max_value = 100.0
+value = 100.0
+show_percentage = false
+
+[node name="HpText" type="Label" parent="Root/Margin/HBox/Stats/HpRow"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(56, 0)
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 14
+text = "100/100"
+horizontal_alignment = 2
+
+[node name="MpRow" type="HBoxContainer" parent="Root/Margin/HBox/Stats"]
+layout_mode = 2
+theme_override_constants/separation = 6
+
+[node name="MpLabel" type="Label" parent="Root/Margin/HBox/Stats/MpRow"]
+custom_minimum_size = Vector2(24, 0)
+layout_mode = 2
+theme_override_colors/font_color = Color(0.5, 0.7, 1, 1)
+theme_override_font_sizes/font_size = 14
+text = "MP"
+
+[node name="MpBar" type="ProgressBar" parent="Root/Margin/HBox/Stats/MpRow"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(120, 10)
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 4
+max_value = 50.0
+value = 50.0
+show_percentage = false
+
+[node name="MpText" type="Label" parent="Root/Margin/HBox/Stats/MpRow"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(56, 0)
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 14
+text = "50/50"
+horizontal_alignment = 2
+
+[node name="GoldLabel" type="Label" parent="Root/Margin/HBox/Stats"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.85, 0.3, 1)
+theme_override_font_sizes/font_size = 14
+text = "$ 0"

--- a/ui/hud/world_inventory.gd
+++ b/ui/hud/world_inventory.gd
@@ -1,0 +1,106 @@
+extends CanvasLayer
+
+const OVERWORLD_PATH_PREFIX := "res://world/"
+const EXCLUDED_PATH_FRAGMENTS := ["tittle_screen", "troca_fase"]
+
+@onready var root_panel: PanelContainer = $Root
+@onready var item_list: VBoxContainer = %ItemList
+@onready var feedback_label: Label = %FeedbackLabel
+@onready var empty_label: Label = %EmptyLabel
+
+var _is_open := false
+
+func _ready() -> void:
+	layer = 20
+	process_mode = Node.PROCESS_MODE_ALWAYS
+	hide()
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("inventory"):
+		get_viewport().set_input_as_handled()
+		if _is_open:
+			_close()
+		elif _can_open():
+			_open()
+		return
+	if _is_open and event.is_action_pressed("ui_cancel"):
+		get_viewport().set_input_as_handled()
+		_close()
+
+func _can_open() -> bool:
+	var current := get_tree().current_scene
+	if current == null:
+		return false
+	var path := current.scene_file_path
+	if not path.begins_with(OVERWORLD_PATH_PREFIX):
+		return false
+	for fragment in EXCLUDED_PATH_FRAGMENTS:
+		if path.contains(fragment):
+			return false
+	return true
+
+func _open() -> void:
+	_is_open = true
+	get_tree().paused = true
+	feedback_label.text = ""
+	_refresh_items()
+	show()
+
+func _close() -> void:
+	_is_open = false
+	get_tree().paused = false
+	hide()
+
+func _refresh_items() -> void:
+	for child in item_list.get_children():
+		child.queue_free()
+
+	var items := GameData.get_inventory_items()
+	empty_label.visible = items.is_empty()
+
+	for item in items:
+		var button := Button.new()
+		button.process_mode = Node.PROCESS_MODE_ALWAYS
+		button.text = _format_item_label(item)
+		button.tooltip_text = item.description
+		button.disabled = not GameData.can_use_world_item(item)
+		button.focus_mode = Control.FOCUS_ALL
+		if not button.disabled:
+			button.pressed.connect(_on_item_pressed.bind(item))
+		item_list.add_child(button)
+
+	await get_tree().process_frame
+	_focus_first_enabled_button()
+
+func _focus_first_enabled_button() -> void:
+	for child in item_list.get_children():
+		if child is Button and not (child as Button).disabled:
+			(child as Button).grab_focus()
+			return
+
+func _format_item_label(item: ItemResource) -> String:
+	var qty := GameData.get_item_quantity(item)
+	var effect := ""
+	match item.effectType:
+		ItemResource.Effect_Type.HEAL_HP:
+			effect = "HP +%d" % item.power
+		ItemResource.Effect_Type.RESTORE_MP:
+			effect = "MP +%d" % item.power
+		ItemResource.Effect_Type.DAMAGE:
+			effect = "DMG %d" % item.power
+	return "%s x%d  -  %s" % [item.name, qty, effect]
+
+func _on_item_pressed(item: ItemResource) -> void:
+	if not GameData.can_use_world_item(item):
+		return
+
+	var party := GameData.party_resources
+	if party.is_empty() or party[0] == null:
+		feedback_label.text = "Nenhum personagem disponível."
+		return
+
+	var target: CharacterResource = party[0]
+	item.apply_to(target)
+	GameData.consume_world_item(item)
+	feedback_label.text = "Usou %s em %s." % [item.name, target.name]
+	_refresh_items()

--- a/ui/hud/world_inventory.tscn
+++ b/ui/hud/world_inventory.tscn
@@ -1,0 +1,96 @@
+[gd_scene format=3 uid="uid://bd1rdwq0yo841"]
+
+[ext_resource type="Script" path="res://ui/hud/world_inventory.gd" id="1_script"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panel"]
+bg_color = Color(0.05, 0.05, 0.08, 0.92)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.9, 0.85, 0.6, 0.85)
+corner_radius_top_left = 8
+corner_radius_top_right = 8
+corner_radius_bottom_right = 8
+corner_radius_bottom_left = 8
+content_margin_left = 16.0
+content_margin_top = 12.0
+content_margin_right = 16.0
+content_margin_bottom = 12.0
+
+[node name="WorldInventory" type="CanvasLayer"]
+layer = 20
+process_mode = 3
+script = ExtResource("1_script")
+
+[node name="Backdrop" type="ColorRect" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 0.5)
+mouse_filter = 0
+
+[node name="Root" type="PanelContainer" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -220.0
+offset_top = -200.0
+offset_right = 220.0
+offset_bottom = 200.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_panel")
+
+[node name="VBox" type="VBoxContainer" parent="Root"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="Title" type="Label" parent="Root/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.95, 0.9, 0.6, 1)
+theme_override_font_sizes/font_size = 22
+text = "INVENTÁRIO"
+horizontal_alignment = 1
+
+[node name="Separator" type="HSeparator" parent="Root/VBox"]
+layout_mode = 2
+
+[node name="Scroll" type="ScrollContainer" parent="Root/VBox"]
+layout_mode = 2
+size_flags_vertical = 3
+horizontal_scroll_mode = 0
+
+[node name="ItemList" type="VBoxContainer" parent="Root/VBox/Scroll"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 4
+
+[node name="EmptyLabel" type="Label" parent="Root/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_color = Color(0.7, 0.7, 0.7, 1)
+theme_override_font_sizes/font_size = 14
+text = "Inventário vazio."
+horizontal_alignment = 1
+visible = false
+
+[node name="FeedbackLabel" type="Label" parent="Root/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_color = Color(0.6, 1, 0.6, 1)
+theme_override_font_sizes/font_size = 14
+text = ""
+horizontal_alignment = 1
+
+[node name="Hint" type="Label" parent="Root/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.7, 0.7, 0.7, 1)
+theme_override_font_sizes/font_size = 12
+text = "I para fechar   /   Enter para usar"
+horizontal_alignment = 1

--- a/world/cripta/game_data.gd
+++ b/world/cripta/game_data.gd
@@ -84,6 +84,27 @@ func consume_battle_item(item: ItemResource) -> bool:
 	battle_inventory[item] = get_item_quantity(item) - 1
 	return true
 
+func get_inventory_items() -> Array[ItemResource]:
+	if battle_inventory.is_empty():
+		reset_default_inventory()
+
+	var items: Array[ItemResource] = []
+	for item in battle_inventory.keys():
+		var item_resource := item as ItemResource
+		if item_resource != null and get_item_quantity(item_resource) > 0:
+			items.append(item_resource)
+	return items
+
+func can_use_world_item(item: ItemResource) -> bool:
+	return item != null and item.can_use_in_world() and get_item_quantity(item) > 0
+
+func consume_world_item(item: ItemResource) -> bool:
+	if not can_use_world_item(item):
+		return false
+
+	battle_inventory[item] = get_item_quantity(item) - 1
+	return true
+
 func add_battle_item(item: ItemResource, quantity: int) -> void:
 	if item == null or quantity <= 0:
 		return


### PR DESCRIPTION
## Summary
- HUD persistente no overworld (retrato, nome/nível, HP/MP, gold) via autoload `WorldHud`
- Overlay de inventário acessível por tecla `I` (toggle) via autoload `WorldInventory`, pausa o tree e permite usar itens com `usableInWorld = true`
- `ItemResource` estendido com `usableInWorld` + `can_use_in_world()`; poção marcada como usável fora de batalha
- `GameData` ganha helpers `get_inventory_items`, `can_use_world_item`, `consume_world_item`
- Resources traduzidos para PT-BR (Herói, Orc Recruta, Sombra do Eco, Guarda de Pedra, Ataque, Cura, Talho, Golpe Focado, Poção); `participantNames` do combo `Golpe Focado` ajustado para refletir o novo nome do Hero

Closes #43

## Test plan
- [ ] HUD aparece em `shroom-lands`, `city_center` e `cripta`
- [ ] HUD some no title screen e durante batalha
- [ ] HP/MP/Gold/Nível atualizam após batalha e após uso de item
- [ ] Tecla `I` abre/fecha inventário; `ESC` também fecha
- [ ] Item com `usableInWorld = true` (Poção) pode ser usado no overworld; HUD reflete cura
- [ ] Item com `usableInWorld = false` aparece listado mas fica desabilitado
- [ ] Botão `Item` na batalha continua funcionando (compartilha estoque com overworld)
- [ ] Combo `Golpe Focado` continua aparecendo quando Herói e Lumen estão prontos
- [ ] Inventário não abre no title screen nem em batalha

🤖 Generated with [Claude Code](https://claude.com/claude-code)